### PR TITLE
remove font call from vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: NanoStringNCTools
 Title: NanoString nCounter Tools
 Description: Tools for NanoString Technologies nCounter Technology.  Provides support for reading RCC files into an ExpressionSet
              derived object.  Also includes methods for QC and normalizaztion of NanoString data.
-Version: 1.7.1
+Version: 1.11.1
 Encoding: UTF-8
 Authors@R: c(person("Patrick", "Aboyoun", role = c("aut")), 
              person("Nicole", "Ortogero", email = "nortogero@nanostring.com", role = c("cre")), 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+Changes in version 1.11.1 (2024-04-10)
++ Remove setting font in vignette
+
 Changes in version 1.7.1 (2022-01-25)
 + Parameters added for update in ggiraph calls
 

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -322,8 +322,6 @@ head(protocolData(demoData)[["QCBorderlineFlags"]], 2)
 The HK Genes QC plot shows the geometric mean of housekeeper genes in each sample. Each dot represents a sample in this plot. The sample IDs are labeled at x-axis. The corresponding geometric mean of housekeeper genes are at y-axis. If you hover mouse over a point, you can find the sample name and its geometric mean. Samples with low housekeeper signal suffer from either low sample input or low reaction efficiency. Ideally the geometric mean of counts will be above 100 for all samples, and a minimum geometric mean of 32 counts is required for analysis. Samples in-between these two thresholds are considered in the analysis, but results from these "borderline" samples should be treated with caution. In this case, all samples are above 100, so they all pass Housekeeping Genes QC.        
 
 ```{r warning = FALSE}
-# set the font Arial
-theme_set(theme_gray(base_family = "Arial"))
 girafe(ggobj = autoplot(demoData, type = "housekeep-geom"))
 ```
 


### PR DESCRIPTION
Remove font call vignette that is causing build errors on bioc

R CMD build / check passes

```
* using log directory ‘/home/rstudio/NanoStringNCTools.Rcheck’
* using R version 4.3.1 (2023-06-16)
* using platform: x86_64-pc-linux-gnu (64-bit)
* R was compiled by
    gcc (Ubuntu 11.3.0-1ubuntu1~22.04.1) 11.3.0
    GNU Fortran (Ubuntu 11.3.0-1ubuntu1~22.04.1) 11.3.0
* running under: Ubuntu 22.04.2 LTS
* using session charset: UTF-8
* using option ‘--no-manual’
* checking for file ‘NanoStringNCTools/DESCRIPTION’ ... OK
* this is package ‘NanoStringNCTools’ version ‘1.7.1’
* package encoding: UTF-8
* checking package namespace information ... OK
* checking package dependencies ... OK
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for executable files ... OK
* checking for hidden files and directories ... NOTE
Found the following hidden files and directories:
  .github
These were most likely included in error. See section ‘Package
structure’ in the ‘Writing R Extensions’ manual.
* checking for portable file names ... OK
* checking for sufficient/correct file permissions ... OK
* checking whether package ‘NanoStringNCTools’ can be installed ... OK
* checking installed package size ... OK
* checking package directory ... OK
* checking ‘build’ directory ... OK
* checking DESCRIPTION meta-information ... NOTE
License components which are templates and need '+ file LICENSE':
  MIT
* checking top-level files ... NOTE
File
  LICENSE
is not mentioned in the DESCRIPTION file.
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking R files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* checking whether the package can be loaded ... OK
* checking whether the package can be loaded with stated dependencies ... OK
* checking whether the package can be unloaded cleanly ... OK
* checking whether the namespace can be loaded with stated dependencies ... OK
* checking whether the namespace can be unloaded cleanly ... OK
* checking loading without being on the library search path ... OK
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... NOTE
autoplot.NanoStringRccSet : <anonymous>: warning in switch(x[2], A =
  qcCutoffs[["BindingDensity"]][["maximumBD"]], B =
  qcCutoffs[["BindingDensity"]][["maximumBD"]], C =
  qcCutoffs[["BindingDensity"]][["maximumBD"]], D =
  qcCutoffs[["BindingDensity"]][["maximumBD"]], E =
  qcCutoffs[["BindingDensity"]][["maximumBD"]], G =
  qcCutoffs[["BindingDensity"]][["maximumBD"]], H =
  qcCutoffs[["BindingDensity"]][["maximumBD"]], P =
  qcCutoffs[["BindingDensity"]][["maximumBDSprint"]], default =
  qcCutoffs[["BindingDensity"]][["maximumBD"]]): partial argument match
  of 'E' to 'EXPR'
setQCFlags,NanoStringRccSet : <anonymous>: warning in switch(x[2], A =
  maxBindDen, B = maxBindDen, C = maxBindDen, D = maxBindDen, E =
  maxBindDen, G = maxBindDen, H = maxBindDen, P = maxBindDenSprint,
  default = maxBindDen): partial argument match of 'E' to 'EXPR'
autoplot.NanoStringRccSet: no visible binding for global variable
  ‘xend’
autoplot.NanoStringRccSet: no visible binding for global variable
  ‘passingThreshold’
autoplot.NanoStringRccSet: no visible binding for global variable
  ‘GeomMean’
autoplot.NanoStringRccSet: no visible binding for global variable ‘h’
autoplot.NanoStringRccSet: no visible binding for global variable
  ‘label’
Undefined global functions or variables:
  GeomMean h label passingThreshold xend
* checking Rd files ... WARNING
checkRd: (5) NanoStringRccSet-class.Rd:147-150: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:151-154: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:155-158: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:159-162: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:163-166: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:167-170: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:171-174: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:175-179: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:180-184: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:185-187: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:188-190: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:191-193: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:194-196: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:202-221: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:229-236: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:237-241: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:242-246: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:247-251: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:252-256: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:257-261: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:262-266: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:267-271: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:277-281: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:282-286: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:287-292: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:298-303: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:304-312: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:318-324: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:330-332: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:338-341: \item in \describe must have non-empty label
checkRd: (5) NanoStringRccSet-class.Rd:342-344: \item in \describe must have non-empty label
checkRd: (5) SignatureSet.Rd:65-67: \item in \describe must have non-empty label
checkRd: (5) SignatureSet.Rd:68-71: \item in \describe must have non-empty label
checkRd: (5) SignatureSet.Rd:72-75: \item in \describe must have non-empty label
checkRd: (5) SignatureSet.Rd:76-79: \item in \describe must have non-empty label
checkRd: (5) SignatureSet.Rd:80-83: \item in \describe must have non-empty label
checkRd: (5) SignatureSet.Rd:84-86: \item in \describe must have non-empty label
checkRd: (5) SignatureSet.Rd:87-89: \item in \describe must have non-empty label
checkRd: (5) SignatureSet.Rd:90-93: \item in \describe must have non-empty label
checkRd: (5) SignatureSet.Rd:94-96: \item in \describe must have non-empty label
checkRd: (5) SignatureSet.Rd:97-99: \item in \describe must have non-empty label
* checking Rd metadata ... OK
* checking Rd cross-references ... OK
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... OK
* checking Rd \usage sections ... OK
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking installed files from ‘inst/doc’ ... OK
* checking files in ‘vignettes’ ... OK
* checking examples ... OK
* checking for unstated dependencies in ‘tests’ ... OK
* checking tests ... OK
  Running ‘run_unitTests.R’
* checking for unstated dependencies in vignettes ... OK
* checking package vignettes in ‘inst/doc’ ... OK
* checking running R code from vignettes ... NONE
  ‘Introduction.Rmd’ using ‘UTF-8’... OK
* checking re-building of vignette outputs ... OK
* DONE
Status: 1 WARNING, 4 NOTEs
```
