### PR TITLE
Environments cannot be NULL

### DIFF
--- a/R/NanoStringRccSet-utils.R
+++ b/R/NanoStringRccSet-utils.R
@@ -33,9 +33,9 @@ setMethod("signatureScoresApply", "NanoStringRccSet", function(X, MARGIN, FUN, .
     parent <- environment(FUN)
     if (is.null(parent)) 
         parent <- emptyenv()
-    environment(FUN) <- new.env(parent = parent)
+    newEnv <- new.env(parent = parent)
     if (length(.kvs) > 0L) {
-        multiassign(names(.kvs), .kvs, environment(FUN))
+        multiassign(x = names(.kvs), value = .kvs, envir = newEnv)
     }
     if (length(.df) == 0L) {
         apply(X, MARGIN = MARGIN, FUN = FUN, ...)
@@ -44,7 +44,7 @@ setMethod("signatureScoresApply", "NanoStringRccSet", function(X, MARGIN, FUN, .
         if (MARGIN == 1L) {
             output <- vector("list", nrow(X))
             for (i in seq_along(output)) {
-                multiassign(colnames(.df), .df[i, ], environment(FUN))
+                multiassign(colnames(.df), .df[i, ], newEnv)
                 output[[i]] <- FUN(X[i, ], ...)
             }
             names(output) <- rownames(X)
@@ -52,7 +52,7 @@ setMethod("signatureScoresApply", "NanoStringRccSet", function(X, MARGIN, FUN, .
         else {
             output <- vector("list", ncol(X))
             for (j in seq_along(output)) {
-                multiassign(colnames(.df), .df[j, ], environment(FUN))
+                multiassign(colnames(.df), .df[j, ], newEnv)
                 output[[j]] <- FUN(X[, j], ...)
             }
             names(output) <- colnames(X)


### PR DESCRIPTION
[Build error on Bioc 3.22](https://bioconductor.org/checkResults/release/bioc-LATEST/NanoStringNCTools/)

```
* checking for file ‘NanoStringNCTools/DESCRIPTION’ ... OK
* preparing ‘NanoStringNCTools’:
* checking DESCRIPTION meta-information ... OK
* installing the package to build vignettes
* creating vignettes ... ERROR
--- re-building ‘Introduction.Rmd’ using rmarkdown

Quitting from Introduction.Rmd:217-232 [unnamed-chunk-9]
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<error/rlang_error>
Error in `multiassign()`:
! envir argument is not an environment
---
Backtrace:
    ▆
 1. ├─NanoStringNCTools::assayDataApply(...)
 2. └─NanoStringNCTools::assayDataApply(...)
 3.   └─NanoStringNCTools (local) .local(X, MARGIN, FUN, ...)
 4.     └─NanoStringNCTools:::.apply(...)
 5.       └─Biobase::multiassign(names(.kvs), .kvs, environment(FUN))
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Error: processing vignette 'Introduction.Rmd' failed with diagnostics:
envir argument is not an environment
--- failed re-building ‘Introduction.Rmd’

SUMMARY: processing the following file failed:
  ‘Introduction.Rmd’

Error: Vignette re-building failed.
Execution halted
```

The true error is a deprecated functionality on setting environments on primitive functions in R4.5. 
`setting environment(<primitive function>) is not possible and trying it is deprecated`

Instead of setting `environment(FUN)` as something, we assign a different variable and use that downstream. 

This .apply function is used in `assayDataApply` and `signatureScoresApply` which is why GeomxTools and GeoMxWorkflows were also failing their builds. 

On R4.5
devtools::check("NanoStringNCTools")
![image](https://github.com/user-attachments/assets/fd93e8a9-d665-411a-89f0-65b6c783c8a2)

devtools::check("GeomxTools") confirm fix downstream
![image](https://github.com/user-attachments/assets/3633540a-5751-45f3-8c00-21c8cd1c70a6)
