### PR TITLE
Bioc build failure 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: NanoStringNCTools
 Title: NanoString nCounter Tools
 Description: Tools for NanoString Technologies nCounter Technology.  Provides support for reading RCC files into an ExpressionSet
              derived object.  Also includes methods for QC and normalizaztion of NanoString data.
-Version: 1.16.2
+Version: 1.21.1
 Encoding: UTF-8
 Authors@R: c(person("Patrick", "Aboyoun", role = c("aut")), 
              person("Nicole", "Ortogero", email = "nortogero@nanostring.com", role = c("aut")), 

--- a/R/NanoStringRccSet-utils.R
+++ b/R/NanoStringRccSet-utils.R
@@ -81,12 +81,12 @@ setMethod("esBy", "NanoStringRccSet", function(X, GROUP, FUN, ..., simplify = TR
         else FUN(X[, keep], ...)
     }, simplify = simplify)
 })
-setMethod("transform", "NanoStringRccSet", function(`_data`, ...) {
+setMethod("transform", "NanoStringRccSet", function(x, ...) {
     exprs <- as.list(substitute(list(...))[-1L])
     if (any(names(exprs) == "")) {
         stop("all arguments in '...' must be named")
     }
-    aData <- assayData(`_data`)
+    aData <- assayData(x)
     isLocked <- environmentIsLocked(aData)
     if (isLocked) {
         aData <- copyEnv(aData)
@@ -96,10 +96,10 @@ setMethod("transform", "NanoStringRccSet", function(`_data`, ...) {
     }
     if (isLocked) {
         lockEnvironment(aData)
-        assayData(`_data`) <- aData
+        assayData(x) <- aData
     }
-    preproc(`_data`)[names(exprs)] <- exprs
-    `_data`
+    preproc(x)[names(exprs)] <- exprs
+    x
 })
 setMethod("with", "NanoStringRccSet", function(data, expr, ...) eval(substitute(expr), 
     as(data, "list"), parent.frame()))


### PR DESCRIPTION
This PR fixes a package build failure caused by the `transform` S4 method for `NanoStringRccSet` using `_data` as its first formal argument.

`BiocGenerics` defines `transform` with an S4 dispatch signature based on `x`. During namespace loading, the mismatched method definition triggered `conformMethod()` and prevented `NanoStringNCTools` from being installed.

The method now:

- Uses `x` as its first formal argument.
- Updates all internal references from `_data` to `x`.
- Preserves the existing transformation behavior, including assay-data updates, locked environment handling, preprocessing metadata, and returning the modified object.


https://bioconductor.org/checkResults/devel/bioc-LATEST/NanoStringNCTools/nebbiolo2-install.html

<img width="1604" height="627" alt="image" src="https://github.com/user-attachments/assets/3ddde97f-072f-4268-8461-3515871d5107" />
